### PR TITLE
Improve @IBDesignable-ness

### DIFF
--- a/MacToggle/MacToggle.swift
+++ b/MacToggle/MacToggle.swift
@@ -94,12 +94,12 @@ class MacToggle: NSView {
     // MARK: Public Parameters
     //================================================================================
 
-    @IBInspectable public var isOn = false {
+    @IBInspectable public var isOn: Bool = false {
         didSet { animate() }
     }
 
     /// Change the toggle border on and off
-    @IBInspectable public var hasToggleBorder = true {
+    @IBInspectable public var hasToggleBorder: Bool = true {
         didSet { circle.layer?.borderWidth = hasToggleBorder ? toggleBorderWidth : 0 }
     }
 

--- a/MacToggle/MacToggle.swift
+++ b/MacToggle/MacToggle.swift
@@ -33,7 +33,12 @@ class MacToggle: NSView {
     // MARK: Properties
     //================================================================================
 
-    fileprivate var height: CGFloat = 44
+    fileprivate var requiredHeight: CGFloat?
+
+    fileprivate var height: CGFloat {
+        get { return requiredHeight ?? bounds.height}
+    }
+
     fileprivate var width: CGFloat {
         get { return height+(height*0.6) }
     }
@@ -159,7 +164,7 @@ class MacToggle: NSView {
     }
 
     required init(height: CGFloat = 44) {
-        self.height = height
+        self.requiredHeight = height
         super.init(frame: .zero)
         drawView()
     }


### PR DESCRIPTION
This PR allows you to do the following in Interface Builder:

* set the height of the control (the width is still automatically determined from the height)
* configure the control's state (on/off) and border boolean properties